### PR TITLE
Use a secret to maintain the sonarqube password instead of a temp file

### DIFF
--- a/roles/tssc-platform/sonarqube/defaults/main.yml
+++ b/roles/tssc-platform/sonarqube/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 sonarqube_project_name: devsecops
 sonarqube_project_display: DevSecOps Common Resources
-sonarqube_password: '{{ lookup("password", tmp_dir + "/sonarqube.password chars=ascii_letters,digits") }}'
 
 rhsso_realm_name: openshift
 rhsso_project_name: rhsso

--- a/roles/tssc-platform/sonarqube/tasks/main.yml
+++ b/roles/tssc-platform/sonarqube/tasks/main.yml
@@ -109,6 +109,5 @@
     pod_delay: 10
     pod_timeout: 600
 
-
 - name: Configure SonarQube and RHSSO to work together
   include: sonarqube_rhsso.yml

--- a/roles/tssc-platform/sonarqube/tasks/main.yml
+++ b/roles/tssc-platform/sonarqube/tasks/main.yml
@@ -109,5 +109,6 @@
     pod_delay: 10
     pod_timeout: 600
 
+
 - name: Configure SonarQube and RHSSO to work together
   include: sonarqube_rhsso.yml

--- a/roles/tssc-platform/sonarqube/tasks/sonarqube_rhsso.yml
+++ b/roles/tssc-platform/sonarqube/tasks/sonarqube_rhsso.yml
@@ -107,6 +107,29 @@
     vars:
       cert_query: "keys[?type == 'RSA'].certificate"
 
+  - name: Fetch sonarqube secret from cluster
+    set_fact:
+      sonarqube_secret_data: "{{ lookup('k8s', kind='Secret', namespace=sonarqube_project_name, resource_name='sonarqube-admin-credentials') }}"
+
+  - name: Set sonarqube password fact from secret
+    set_fact:
+      sonarqube_password: "{{ sonarqube_secret_data.data.password | b64decode }}"
+    when:
+      - sonarqube_secret_data != []
+
+  - name: Create secret if missing
+    block:
+    - name: generate sonarqube credential facts
+      set_fact:
+        sonarqube_username: admin
+        sonarqube_password: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}"
+    - name: create secret
+      k8s:
+        namespace: '{{ sonarqube_project_name }}'
+        definition: "{{ lookup('template', 'sonarqube-secret.yml.j2') }}"
+    when:
+    - sonarqube_secret_data == []
+
   - name: Update sonarqube settings
     shell: >-
       devsecops-api sonarqube update-setting

--- a/roles/tssc-platform/sonarqube/templates/sonarqube-secret.yml.j2
+++ b/roles/tssc-platform/sonarqube/templates/sonarqube-secret.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sonarqube-admin-credentials
+type: Opaque
+data:
+  username: "{{ sonarqube_username | b64encode }}"
+  password: "{{ sonarqube_password | b64encode }}"


### PR DESCRIPTION
Closes #26 